### PR TITLE
Enable checkout with zero cost order

### DIFF
--- a/src/app/commerce/checkout.service.ts
+++ b/src/app/commerce/checkout.service.ts
@@ -187,6 +187,28 @@ export class CheckoutService {
 
     }
 
+    complete_free_order() : Observable<string> {
+
+	let svc = this;
+
+	return new Observable<string>(obs => {
+
+	    this.commerce.complete_free_order(this._order).subscribe({
+		next(b) {
+		    // Re-fetch offer.
+		    svc.reset();
+		    obs.next(b);
+		},
+		error(err : Error) {
+		    obs.error(err)
+		},
+		complete() { obs.complete() }
+	    });
+
+	});
+
+    }
+
     get_crypto_currencies() {
 	return this.commerce.get_currencies();
     }

--- a/src/app/commerce/commerce.service.ts
+++ b/src/app/commerce/commerce.service.ts
@@ -77,6 +77,20 @@ export class CommerceService {
 
     }
 
+    complete_free_order(order : Order) : Observable<any> {
+
+	let url = "/api/commerce/complete-free-order";
+
+	return new Observable<any>(obs => {
+
+	    this.api.post<any>(url, order).subscribe(b => {
+		obs.next(b);
+	    });
+
+	});
+
+    }
+
     create_payment(id : string) : Observable<any> {
 	let url = "/api/commerce/create-payment/" + id;
 

--- a/src/app/commerce/complete/complete.component.html
+++ b/src/app/commerce/complete/complete.component.html
@@ -12,7 +12,7 @@
 
 	<h1><mat-icon>done</mat-icon>Payment complete</h1>
 
-	Your payment completed successfully.  A receipt has been emailed to you.
+	Your order processed successfully.
 
       </section>
       

--- a/src/app/commerce/shop/shop.component.html
+++ b/src/app/commerce/shop/shop.component.html
@@ -78,24 +78,33 @@
 
       </section>
 
-      <section class="content" *ngIf="order.total > 0">
+      <section class="content" *ngIf="order.items.length > 0">
 
 	<h1>Your order</h1>
 
 	<order></order>
 
 	<div>
-	  <button mat-raised-button color="primary"
-		  (click)="cc_checkout()" [disabled]="order_disabled()">
-	    <mat-icon>credit_card</mat-icon>&nbsp;
-	    Pay with credit card
-	  </button>
-	  <button mat-raised-button color="primary"
-		  *ngIf="feature('crypto')"
-		  (click)="crypto_checkout()" [disabled]="order_disabled()">
-	    <mat-icon>currency_bitcoin</mat-icon>&nbsp;
-	    Pay with cryptocurrency
-	  </button>
+	  <ng-container *ngIf="free_order_available()">
+	    <button mat-raised-button color="primary"
+		    (click)="free_checkout()">
+	      <mat-icon>redeem</mat-icon>&nbsp;
+	      Process free order
+	    </button>
+	  </ng-container>
+	  <ng-container *ngIf="!free_order_available()">
+	    <button mat-raised-button color="primary"
+		    (click)="cc_checkout()" [disabled]="order_disabled()">
+	      <mat-icon>credit_card</mat-icon>&nbsp;
+	      Pay with credit card
+	    </button>
+	    <button mat-raised-button color="primary"
+		    *ngIf="feature('crypto')"
+		    (click)="crypto_checkout()" [disabled]="order_disabled()">
+	      <mat-icon>currency_bitcoin</mat-icon>&nbsp;
+	      Pay with cryptocurrency
+	    </button>
+	  </ng-container>
 	  <button mat-raised-button color="basic" (click)="reset()">
 	    <mat-icon>clear</mat-icon>&nbsp;
 	    Reset checkout
@@ -109,6 +118,4 @@
   </mat-drawer-container>
 
 </section>
-
-
 

--- a/src/app/commerce/shop/shop.component.ts
+++ b/src/app/commerce/shop/shop.component.ts
@@ -95,6 +95,13 @@ export class ShopComponent implements OnInit {
 	this.router.navigate(["/commerce/cc-checkout"]);
     }
 
+    free_checkout() {
+	this.service.complete_free_order().subscribe(o => {
+	    this.router.navigate(["/commerce/complete"]);
+	});
+	this.reset();
+    }
+
     crypto_checkout() {
 	this.router.navigate(["/commerce/crypto-checkout"]);
     }
@@ -108,6 +115,12 @@ export class ShopComponent implements OnInit {
 
     order_disabled() {
 	return (this.order.total < 1);
+    }
+
+    free_order_available() {
+    console.log(this.order);
+    console.log(this.order.total == 0);
+	return (this.order.items.length > 0) && (this.order.total == 0);
     }
 
     full_credits() {


### PR DESCRIPTION
Enable checkout with zero cost order. The checkout process cuts out the need for a credit card. It uses a free order API endpoint in the back end, which only works on zero cost orders.
